### PR TITLE
Add initial rpp-stark architecture skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rpp-stark"
+version = "0.1.0"
+edition = "2021"
+authors = ["RPP Core Team"]
+description = "Deterministic STARK proof engine for the RPP blockchain."
+license = "MIT"
+
+[lib]
+name = "rpp_stark"
+path = "src/lib.rs"
+crate-type = ["rlib"]
+
+[dependencies]

--- a/src/air/boundary.rs
+++ b/src/air/boundary.rs
@@ -1,0 +1,20 @@
+//! Boundary constraint helpers for AIR definitions.
+//! Provides deterministic enforcement of initial and final state conditions.
+
+use crate::field::FieldElement;
+
+/// Boundary constraint defined by fixed values at specific steps.
+#[derive(Debug, Clone)]
+pub struct BoundaryConstraint {
+    /// Step index in the trace.
+    pub step: usize,
+    /// Expected register values at the step.
+    pub values: Vec<FieldElement>,
+}
+
+impl BoundaryConstraint {
+    /// Creates a new boundary constraint descriptor.
+    pub fn new(step: usize, values: Vec<FieldElement>) -> Self {
+        Self { step, values }
+    }
+}

--- a/src/air/constraints.rs
+++ b/src/air/constraints.rs
@@ -1,0 +1,20 @@
+//! Constraint traits describing the AIR interface.
+//! Applications implement these traits to define algebraic constraints.
+
+use crate::field::FieldElement;
+
+/// Trait representing the Algebraic Intermediate Representation for a computation.
+pub trait Air {
+    /// Returns the number of registers in the execution trace.
+    fn trace_width(&self) -> usize;
+    /// Returns the transition constraint evaluator.
+    fn transition(&self) -> &dyn ConstraintEvaluator;
+    /// Returns the boundary constraint evaluator.
+    fn boundary(&self) -> &dyn ConstraintEvaluator;
+}
+
+/// Trait implemented by deterministic constraint evaluators.
+pub trait ConstraintEvaluator {
+    /// Evaluates constraints at the provided step and returns the resulting values.
+    fn evaluate(&self, step: usize, registers: &[FieldElement]) -> Vec<FieldElement>;
+}

--- a/src/air/mod.rs
+++ b/src/air/mod.rs
@@ -1,0 +1,8 @@
+//! Algebraic Intermediate Representation (AIR) module.
+//! Provides traits for defining transition and boundary constraints used in STARK proofs.
+
+pub mod boundary;
+pub mod constraints;
+pub mod transition;
+
+pub use constraints::{Air, ConstraintEvaluator};

--- a/src/air/transition.rs
+++ b/src/air/transition.rs
@@ -1,0 +1,27 @@
+//! Transition constraint helpers.
+//! Contains deterministic evaluation logic used across AIR implementations.
+
+use crate::field::FieldElement;
+
+/// Transition constraint representation storing evaluation coefficients.
+#[derive(Debug, Clone)]
+pub struct TransitionConstraint {
+    /// Coefficients of the constraint polynomial.
+    pub coefficients: Vec<FieldElement>,
+}
+
+impl TransitionConstraint {
+    /// Constructs a new transition constraint.
+    pub fn new(coefficients: Vec<FieldElement>) -> Self {
+        Self { coefficients }
+    }
+
+    /// Evaluates the transition constraint at the provided state.
+    pub fn evaluate(&self, registers: &[FieldElement]) -> FieldElement {
+        let mut acc = FieldElement::zero();
+        for (coeff, reg) in self.coefficients.iter().zip(registers.iter()) {
+            acc = acc.add(coeff.mul(*reg));
+        }
+        acc
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,69 @@
+//! Configuration module for the `rpp-stark` engine.
+//! Provides strongly typed contexts used to parameterize proof generation and verification.
+
+use crate::field::prime_field::Modulus;
+use crate::{fri::config::FriParameters, hash::config::HashParameters};
+
+/// Shared configuration between prover and verifier specifying the evaluation domain and FRI setup.
+#[derive(Debug, Clone)]
+pub struct StarkConfig {
+    /// The size of the trace domain.
+    pub trace_length: usize,
+    /// Field modulus configuration.
+    pub field_modulus: Modulus,
+    /// FRI parameters describing folding strategy.
+    pub fri: FriParameters,
+    /// Hash configuration for commitments and transcripts.
+    pub hash: HashParameters,
+}
+
+impl StarkConfig {
+    /// Validates the configuration and produces a deterministic error on failure.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.trace_length == 0 {
+            return Err("trace length must be non-zero");
+        }
+        if !self.field_modulus.is_prime {
+            return Err("field modulus must be prime");
+        }
+        Ok(())
+    }
+}
+
+/// Context used by the prover to drive proof generation.
+#[derive(Debug, Clone)]
+pub struct ProverContext {
+    /// Global STARK configuration shared with the verifier.
+    pub stark: StarkConfig,
+    /// Optional thread count for deterministic batching.
+    pub max_threads: usize,
+}
+
+impl ProverContext {
+    /// Constructs a new prover context with deterministic defaults.
+    pub fn new(stark: StarkConfig) -> Self {
+        Self {
+            stark,
+            max_threads: 1,
+        }
+    }
+}
+
+/// Context used by the verifier to execute deterministic verification logic.
+#[derive(Debug, Clone)]
+pub struct VerifierContext {
+    /// Global STARK configuration shared with the prover.
+    pub stark: StarkConfig,
+    /// Number of sampling queries performed during verification.
+    pub query_count: usize,
+}
+
+impl VerifierContext {
+    /// Constructs a new verifier context.
+    pub fn new(stark: StarkConfig) -> Self {
+        Self {
+            stark,
+            query_count: 0,
+        }
+    }
+}

--- a/src/fft/ifft.rs
+++ b/src/fft/ifft.rs
@@ -1,0 +1,29 @@
+//! Inverse FFT routines for polynomial reconstruction.
+//! Provides deterministic algorithms for use in the FRI commitment scheme.
+
+use crate::field::{polynomial::Polynomial, FieldElement};
+use crate::StarkError;
+use crate::StarkResult;
+
+/// Inverse FFT operator placeholder.
+#[derive(Debug, Clone)]
+pub struct InverseFft {
+    /// Domain size used for interpolation.
+    pub domain_size: usize,
+}
+
+impl InverseFft {
+    /// Creates a new inverse FFT operator with the provided domain size.
+    pub fn new(domain_size: usize) -> Self {
+        Self { domain_size }
+    }
+
+    /// Reconstructs a polynomial from evaluation points.
+    pub fn interpolate(&self, evaluations: &[FieldElement]) -> StarkResult<Polynomial> {
+        if evaluations.is_empty() || evaluations.len() != self.domain_size {
+            return Err(StarkError::InvalidInput("invalid evaluation length"));
+        }
+        // Placeholder deterministic interpolation using direct assignment.
+        Ok(Polynomial::new(evaluations.to_vec()))
+    }
+}

--- a/src/fft/lde.rs
+++ b/src/fft/lde.rs
@@ -1,0 +1,35 @@
+//! Low-degree extension routines for the evaluation domain.
+//! Performs deterministic polynomial extension over multiplicative cosets.
+
+use crate::field::{polynomial::Polynomial, FieldElement};
+use crate::StarkError;
+use crate::StarkResult;
+
+/// Deterministic descriptor for LDE operations.
+#[derive(Debug, Clone)]
+pub struct LowDegreeExtension {
+    /// Target domain size after extension.
+    pub blowup_factor: usize,
+}
+
+impl LowDegreeExtension {
+    /// Creates a new LDE descriptor.
+    pub fn new(blowup_factor: usize) -> Self {
+        Self { blowup_factor }
+    }
+
+    /// Executes the low-degree extension, returning the evaluations over the expanded domain.
+    pub fn extend(&self, polynomial: &Polynomial) -> StarkResult<Vec<FieldElement>> {
+        if self.blowup_factor == 0 {
+            return Err(StarkError::InvalidInput("blowup factor must be non-zero"));
+        }
+        // Placeholder deterministic implementation using naive evaluation.
+        let domain_size = polynomial.coefficients.len() * self.blowup_factor;
+        let mut result = Vec::with_capacity(domain_size);
+        for i in 0..domain_size {
+            let point = FieldElement::new(i as u64);
+            result.push(polynomial.evaluate(point));
+        }
+        Ok(result)
+    }
+}

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -1,0 +1,8 @@
+//! Fast Fourier Transform utilities for the `rpp-stark` engine.
+//! Includes low-degree extension (LDE) and inverse FFT operations for polynomial evaluation.
+
+pub mod ifft;
+pub mod lde;
+
+pub use ifft::InverseFft;
+pub use lde::LowDegreeExtension;

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -1,0 +1,7 @@
+//! Field arithmetic primitives for the `rpp-stark` proof system.
+//! Contains finite field implementations and polynomial utilities.
+
+pub mod polynomial;
+pub mod prime_field;
+
+pub use prime_field::FieldElement;

--- a/src/field/polynomial.rs
+++ b/src/field/polynomial.rs
@@ -1,0 +1,37 @@
+//! Polynomial utilities operating over the prime field.
+//! The module provides deterministic arithmetic for trace and constraint polynomials.
+
+use super::FieldElement;
+
+/// Dense polynomial represented by coefficients in ascending order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Polynomial {
+    /// Coefficients starting from the constant term.
+    pub coefficients: Vec<FieldElement>,
+}
+
+impl Polynomial {
+    /// Constructs a polynomial from raw coefficients.
+    pub fn new(coefficients: Vec<FieldElement>) -> Self {
+        Self { coefficients }
+    }
+
+    /// Evaluates the polynomial at the provided point using Horner's method.
+    pub fn evaluate(&self, point: FieldElement) -> FieldElement {
+        let mut result = FieldElement::zero();
+        for coeff in self.coefficients.iter().rev() {
+            result = result.mul(point).add(*coeff);
+        }
+        result
+    }
+
+    /// Returns the degree of the polynomial or `None` if the polynomial is zero.
+    pub fn degree(&self) -> Option<usize> {
+        for (idx, coeff) in self.coefficients.iter().enumerate().rev() {
+            if coeff.as_u64() != 0 {
+                return Some(idx);
+            }
+        }
+        None
+    }
+}

--- a/src/field/prime_field.rs
+++ b/src/field/prime_field.rs
@@ -1,0 +1,112 @@
+//! Prime field implementation tailored for the `rpp-stark` engine.
+//! Provides deterministic arithmetic over a statically defined prime modulus.
+
+use core::fmt;
+
+/// Metadata describing the underlying field modulus.
+#[derive(Debug, Clone, Copy)]
+pub struct Modulus {
+    /// Prime modulus value.
+    pub value: u64,
+    /// Indicates whether the modulus passed primality checks during configuration.
+    pub is_prime: bool,
+}
+
+impl Modulus {
+    /// Creates a new modulus descriptor.
+    pub const fn new(value: u64, is_prime: bool) -> Self {
+        Self { value, is_prime }
+    }
+}
+
+/// Canonical generator for the default field used across the system.
+pub const DEFAULT_MODULUS: Modulus = Modulus::new(0xffffffff00000001, true);
+
+/// Field element represented as a canonical value modulo the prime.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub struct FieldElement {
+    /// Canonical representative in the range `[0, modulus)`.
+    value: u64,
+}
+
+impl FieldElement {
+    /// Returns the additive identity.
+    pub const fn zero() -> Self {
+        Self { value: 0 }
+    }
+
+    /// Returns the multiplicative identity.
+    pub const fn one() -> Self {
+        Self { value: 1 }
+    }
+
+    /// Constructs an element from a raw value reduced modulo the default modulus.
+    pub fn new(value: u64) -> Self {
+        Self {
+            value: value % DEFAULT_MODULUS.value,
+        }
+    }
+
+    /// Exposes the underlying canonical value.
+    pub fn as_u64(&self) -> u64 {
+        self.value
+    }
+
+    /// Computes the modular addition of two field elements.
+    pub fn add(self, other: Self) -> Self {
+        let modulus = DEFAULT_MODULUS.value;
+        let sum = self.value.wrapping_add(other.value);
+        let mut result = sum;
+        if result >= modulus || sum < self.value {
+            result = result.wrapping_sub(modulus);
+        }
+        Self { value: result }
+    }
+
+    /// Computes modular subtraction.
+    pub fn sub(self, other: Self) -> Self {
+        let modulus = DEFAULT_MODULUS.value;
+        let mut result = self.value.wrapping_sub(other.value);
+        if self.value < other.value {
+            result = result.wrapping_add(modulus);
+        }
+        Self { value: result }
+    }
+
+    /// Computes modular multiplication using 128-bit widening.
+    pub fn mul(self, other: Self) -> Self {
+        let modulus = DEFAULT_MODULUS.value as u128;
+        let product = (self.value as u128) * (other.value as u128);
+        Self {
+            value: (product % modulus) as u64,
+        }
+    }
+
+    /// Computes modular exponentiation via square-and-multiply.
+    pub fn pow(self, mut exp: u64) -> Self {
+        let mut result = Self::one();
+        let mut base = self;
+        while exp > 0 {
+            if exp & 1 == 1 {
+                result = result.mul(base);
+            }
+            base = base.mul(base);
+            exp >>= 1;
+        }
+        result
+    }
+
+    /// Computes the multiplicative inverse using Fermat's little theorem.
+    pub fn inv(self) -> Option<Self> {
+        if self.value == 0 {
+            return None;
+        }
+        Some(self.pow(DEFAULT_MODULUS.value - 2))
+    }
+}
+
+impl fmt::Debug for FieldElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("FieldElement").field(&self.value).finish()
+    }
+}

--- a/src/fri/batch.rs
+++ b/src/fri/batch.rs
@@ -1,0 +1,27 @@
+//! Batch verification utilities for FRI proofs.
+//! Allows verifying multiple queries concurrently in a deterministic manner.
+
+use super::proof::FriProof;
+use crate::{StarkError, StarkResult};
+
+/// Batch verifier placeholder for FRI proofs.
+#[derive(Debug, Clone)]
+pub struct FriBatch {
+    /// Number of proofs aggregated in the batch.
+    pub proofs: Vec<FriProof>,
+}
+
+impl FriBatch {
+    /// Creates a new batch container.
+    pub fn new(proofs: Vec<FriProof>) -> Self {
+        Self { proofs }
+    }
+
+    /// Executes deterministic verification across the batch.
+    pub fn verify(&self) -> StarkResult<bool> {
+        if self.proofs.is_empty() {
+            return Err(StarkError::InvalidInput("fri batch cannot be empty"));
+        }
+        Ok(true)
+    }
+}

--- a/src/fri/config.rs
+++ b/src/fri/config.rs
@@ -1,0 +1,24 @@
+//! Configuration objects for the FRI protocol.
+//! Defines folding schedule and query parameters used across prover and verifier.
+
+/// Parameters describing the FRI folding schedule.
+#[derive(Debug, Clone)]
+pub struct FriParameters {
+    /// Number of queries sampled during verification.
+    pub query_count: usize,
+    /// Logarithmic domain size.
+    pub log_domain_size: usize,
+    /// Folding factor applied at each layer.
+    pub folding_factor: usize,
+}
+
+impl FriParameters {
+    /// Creates a new parameter set.
+    pub fn new(query_count: usize, log_domain_size: usize, folding_factor: usize) -> Self {
+        Self {
+            query_count,
+            log_domain_size,
+            folding_factor,
+        }
+    }
+}

--- a/src/fri/folding.rs
+++ b/src/fri/folding.rs
@@ -1,0 +1,47 @@
+//! FRI folding strategy definitions.
+//! Provides deterministic folding operations for polynomial commitments.
+
+use crate::field::FieldElement;
+use crate::{StarkError, StarkResult};
+
+/// Represents a single layer in the FRI folding process.
+#[derive(Debug, Clone)]
+pub struct FriLayer {
+    /// Evaluation points at the current layer.
+    pub evaluations: Vec<FieldElement>,
+}
+
+/// Deterministic folding operator.
+#[derive(Debug, Clone)]
+pub struct FriFolding {
+    /// Folding factor applied at each layer.
+    pub folding_factor: usize,
+}
+
+impl FriFolding {
+    /// Creates a new folding descriptor.
+    pub fn new(folding_factor: usize) -> Self {
+        Self { folding_factor }
+    }
+
+    /// Performs a single folding step, reducing the number of evaluations.
+    pub fn fold(&self, layer: &FriLayer) -> StarkResult<FriLayer> {
+        if self.folding_factor == 0 {
+            return Err(StarkError::InvalidInput("folding factor must be non-zero"));
+        }
+        if layer.evaluations.len() % self.folding_factor != 0 {
+            return Err(StarkError::InvalidInput(
+                "evaluations length must be divisible by folding factor",
+            ));
+        }
+        let mut next = Vec::with_capacity(layer.evaluations.len() / self.folding_factor);
+        for chunk in layer.evaluations.chunks(self.folding_factor) {
+            let mut acc = FieldElement::zero();
+            for value in chunk {
+                acc = acc.add(*value);
+            }
+            next.push(acc);
+        }
+        Ok(FriLayer { evaluations: next })
+    }
+}

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -1,0 +1,11 @@
+//! FRI commitment scheme primitives.
+//! Provides folding strategies, proof representation, and batch verification utilities.
+
+pub mod batch;
+pub mod config;
+pub mod folding;
+pub mod proof;
+
+pub use batch::FriBatch;
+pub use folding::{FriFolding, FriLayer};
+pub use proof::{FriProof, FriQuery};

--- a/src/fri/proof.rs
+++ b/src/fri/proof.rs
@@ -1,0 +1,32 @@
+//! FRI proof representation.
+//! Defines serialisable structures used during proof generation and verification.
+
+use crate::field::FieldElement;
+
+/// Represents a single query within a FRI proof.
+#[derive(Debug, Clone)]
+pub struct FriQuery {
+    /// Index of the sampled position.
+    pub index: usize,
+    /// Evaluations associated with the query.
+    pub values: Vec<FieldElement>,
+}
+
+/// Full FRI proof containing folded layers and query openings.
+#[derive(Debug, Clone)]
+pub struct FriProof {
+    /// Layers produced during folding.
+    pub layers: Vec<Vec<FieldElement>>,
+    /// Queries sampled for verification.
+    pub queries: Vec<FriQuery>,
+}
+
+impl FriProof {
+    /// Creates an empty FRI proof.
+    pub fn new() -> Self {
+        Self {
+            layers: Vec::new(),
+            queries: Vec::new(),
+        }
+    }
+}

--- a/src/hash/blake3.rs
+++ b/src/hash/blake3.rs
@@ -1,0 +1,50 @@
+//! Blake3 hashing for transcript derivation.
+//! The implementation is deterministic and self-contained for the STARK engine.
+
+use super::config::Blake3Parameters;
+use crate::{StarkError, StarkResult};
+
+/// Blake3 hasher placeholder maintaining an internal state.
+#[derive(Debug, Clone)]
+pub struct Blake3Hasher {
+    /// Domain separation label applied to every hash invocation.
+    pub label: &'static [u8],
+    /// Internal state represented as bytes.
+    state: Vec<u8>,
+}
+
+impl Blake3Hasher {
+    /// Creates a new hasher with the provided parameters.
+    pub fn new(params: Blake3Parameters) -> Self {
+        Self {
+            label: params.label,
+            state: params.label.to_vec(),
+        }
+    }
+
+    /// Absorbs bytes into the hash state.
+    pub fn absorb(&mut self, data: &[u8]) {
+        self.state.extend_from_slice(data);
+    }
+
+    /// Finalizes the hash computation and returns a deterministic digest.
+    pub fn finalize(&self) -> StarkResult<[u8; 32]> {
+        if self.state.is_empty() {
+            return Err(StarkError::InvalidInput("blake3 state empty"));
+        }
+        let mut output = [0u8; 32];
+        for (i, byte) in self.state.iter().enumerate() {
+            let index = i % output.len();
+            output[index] = output[index]
+                .wrapping_add(*byte)
+                .wrapping_add((i as u8) ^ 0x5a);
+        }
+        Ok(output)
+    }
+
+    /// Convenience helper hashing arbitrary data in one call.
+    pub fn hash(&mut self, data: &[u8]) -> StarkResult<[u8; 32]> {
+        self.absorb(data);
+        self.finalize()
+    }
+}

--- a/src/hash/config.rs
+++ b/src/hash/config.rs
@@ -1,0 +1,54 @@
+//! Hash configuration definitions shared across prover and verifier.
+//! Parameters ensure deterministic hash usage within transcripts and commitments.
+
+/// Poseidon parameter set descriptor.
+#[derive(Debug, Clone)]
+pub struct PoseidonParameters {
+    /// Number of full rounds in the permutation.
+    pub full_rounds: usize,
+    /// Number of partial rounds in the permutation.
+    pub partial_rounds: usize,
+    /// Width of the permutation state.
+    pub width: usize,
+}
+
+impl PoseidonParameters {
+    /// Creates a new parameter set with deterministic defaults.
+    pub fn new(full_rounds: usize, partial_rounds: usize, width: usize) -> Self {
+        Self {
+            full_rounds,
+            partial_rounds,
+            width,
+        }
+    }
+}
+
+/// Blake3 parameter descriptor for transcript usage.
+#[derive(Debug, Clone)]
+pub struct Blake3Parameters {
+    /// Fixed domain separation label.
+    pub label: &'static [u8],
+}
+
+impl Blake3Parameters {
+    /// Creates a new descriptor.
+    pub const fn new(label: &'static [u8]) -> Self {
+        Self { label }
+    }
+}
+
+/// Aggregate hash parameters used by the STARK engine.
+#[derive(Debug, Clone)]
+pub struct HashParameters {
+    /// Poseidon permutation configuration.
+    pub poseidon: PoseidonParameters,
+    /// Blake3 transcript configuration.
+    pub blake3: Blake3Parameters,
+}
+
+impl HashParameters {
+    /// Constructs aggregate parameters.
+    pub fn new(poseidon: PoseidonParameters, blake3: Blake3Parameters) -> Self {
+        Self { poseidon, blake3 }
+    }
+}

--- a/src/hash/merkle.rs
+++ b/src/hash/merkle.rs
@@ -1,0 +1,75 @@
+//! Merkle tree commitments constructed from Blake3 hashes.
+//! Provides deterministic construction and proof verification routines.
+
+use super::Blake3Hasher;
+use crate::{StarkError, StarkResult};
+
+/// Merkle path element representing a neighbour hash and its orientation.
+#[derive(Debug, Clone)]
+pub struct MerklePath {
+    /// Sibling hash bytes.
+    pub sibling: [u8; 32],
+    /// Indicates whether the sibling is on the left.
+    pub left: bool,
+}
+
+/// Deterministic Merkle tree implementation.
+#[derive(Debug, Clone)]
+pub struct MerkleTree {
+    /// Leaf hashes forming the base layer.
+    pub leaves: Vec<[u8; 32]>,
+}
+
+impl MerkleTree {
+    /// Constructs a new Merkle tree from leaf data using the provided hasher factory.
+    pub fn new(leaves: Vec<[u8; 32]>) -> StarkResult<Self> {
+        if leaves.is_empty() {
+            return Err(StarkError::InvalidInput(
+                "merkle tree requires at least one leaf",
+            ));
+        }
+        Ok(Self { leaves })
+    }
+
+    /// Computes the Merkle root deterministically.
+    pub fn root(&self, mut hasher: Blake3Hasher) -> StarkResult<[u8; 32]> {
+        let mut current = self.leaves.clone();
+        while current.len() > 1 {
+            let mut next = Vec::with_capacity((current.len() + 1) / 2);
+            for chunk in current.chunks(2) {
+                let pair = if chunk.len() == 2 {
+                    [chunk[0], chunk[1]]
+                } else {
+                    [chunk[0], chunk[0]]
+                };
+                hasher.absorb(&pair[0]);
+                hasher.absorb(&pair[1]);
+                next.push(hasher.finalize()?);
+            }
+            current = next;
+        }
+        Ok(current[0])
+    }
+
+    /// Verifies a Merkle path against the root.
+    pub fn verify(
+        &self,
+        mut hasher: Blake3Hasher,
+        leaf: [u8; 32],
+        path: &[MerklePath],
+        expected_root: [u8; 32],
+    ) -> StarkResult<bool> {
+        let mut hash = leaf;
+        for step in path {
+            if step.left {
+                hasher.absorb(&step.sibling);
+                hasher.absorb(&hash);
+            } else {
+                hasher.absorb(&hash);
+                hasher.absorb(&step.sibling);
+            }
+            hash = hasher.finalize()?;
+        }
+        Ok(hash == expected_root)
+    }
+}

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -1,0 +1,12 @@
+//! Hashing primitives for the `rpp-stark` engine.
+//! Contains Poseidon for field-friendly hashing, Blake3 for byte hashing, and Merkle commitments.
+
+pub mod blake3;
+pub mod config;
+pub mod merkle;
+pub mod poseidon;
+
+pub use blake3::Blake3Hasher;
+pub use config::{Blake3Parameters, HashParameters, PoseidonParameters};
+pub use merkle::{MerklePath, MerkleTree};
+pub use poseidon::PoseidonState;

--- a/src/hash/poseidon.rs
+++ b/src/hash/poseidon.rs
@@ -1,0 +1,59 @@
+//! Poseidon hash permutation for field elements.
+//! The implementation is a placeholder outlining the deterministic interface.
+
+use super::config::PoseidonParameters;
+use crate::field::FieldElement;
+use crate::{StarkError, StarkResult};
+
+/// Poseidon state representation used during hashing.
+#[derive(Debug, Clone)]
+pub struct PoseidonState {
+    /// Current state elements.
+    pub elements: Vec<FieldElement>,
+    /// Poseidon parameters controlling the permutation.
+    pub parameters: PoseidonParameters,
+}
+
+impl PoseidonState {
+    /// Creates a new Poseidon state initialised with zero elements.
+    pub fn new(parameters: PoseidonParameters) -> Self {
+        let mut elements = Vec::with_capacity(parameters.width);
+        elements.resize(parameters.width, FieldElement::zero());
+        Self {
+            elements,
+            parameters,
+        }
+    }
+
+    /// Absorbs field elements into the state using a deterministic sponge interface.
+    pub fn absorb(&mut self, input: &[FieldElement]) {
+        for (i, value) in input.iter().enumerate() {
+            let index = i % self.elements.len();
+            self.elements[index] = self.elements[index].add(*value);
+        }
+    }
+
+    /// Applies the Poseidon permutation rounds.
+    pub fn permute(&mut self) {
+        for _ in 0..self.parameters.full_rounds {
+            for element in &mut self.elements {
+                *element = element.pow(5);
+            }
+        }
+    }
+
+    /// Extracts a deterministic field element from the state.
+    pub fn squeeze(&mut self) -> FieldElement {
+        self.permute();
+        self.elements[0]
+    }
+
+    /// Convenience helper producing a hash digest from an input slice.
+    pub fn hash(&mut self, input: &[FieldElement]) -> StarkResult<FieldElement> {
+        if input.is_empty() {
+            return Err(StarkError::InvalidInput("poseidon input cannot be empty"));
+        }
+        self.absorb(input);
+        Ok(self.squeeze())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,40 @@
+//! Core library entry point for the `rpp-stark` proof system.
+//! This module exposes the high-level and low-level APIs for proof generation and verification.
+
+pub mod air;
+pub mod config;
+pub mod fft;
+pub mod field;
+pub mod fri;
+pub mod hash;
+pub mod proof;
+pub mod utils;
+
+use proof::{prover::Prover, verifier::Verifier};
+use utils::serialization::ProofBytes;
+
+/// Result type used throughout the library to surface deterministic errors.
+pub type StarkResult<T> = core::result::Result<T, StarkError>;
+
+/// Error enumeration for the STARK engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StarkError {
+    /// The requested feature is not yet implemented.
+    NotImplemented(&'static str),
+    /// The provided input failed validation checks.
+    InvalidInput(&'static str),
+    /// A generic error surfaced from a subsystem.
+    SubsystemFailure(&'static str),
+}
+
+/// High-level interface for proof generation.
+pub fn generate_proof(context: &config::ProverContext) -> StarkResult<ProofBytes> {
+    let prover = Prover::new(context.clone());
+    prover.create_proof()
+}
+
+/// High-level interface for proof verification.
+pub fn verify_proof(context: &config::VerifierContext, proof: &ProofBytes) -> StarkResult<bool> {
+    let verifier = Verifier::new(context.clone());
+    verifier.verify(proof)
+}

--- a/src/proof/mod.rs
+++ b/src/proof/mod.rs
@@ -1,0 +1,8 @@
+//! Proof generation and verification subsystem.
+//! Provides embedded prover and verifier implementations for the STARK engine.
+
+pub mod prover;
+pub mod verifier;
+
+pub use prover::Prover;
+pub use verifier::Verifier;

--- a/src/proof/prover.rs
+++ b/src/proof/prover.rs
@@ -1,0 +1,50 @@
+//! Prover implementation for the `rpp-stark` engine.
+//! Executes the polynomial commitment pipeline to produce deterministic proofs.
+
+use crate::air::Air;
+use crate::config::ProverContext;
+use crate::fri::{FriBatch, FriProof};
+use crate::hash::{Blake3Hasher, MerkleTree};
+use crate::utils::serialization::ProofBytes;
+use crate::{StarkError, StarkResult};
+
+/// Prover struct encapsulating the deterministic pipeline.
+#[derive(Debug, Clone)]
+pub struct Prover {
+    /// Context containing configuration parameters.
+    pub context: ProverContext,
+}
+
+impl Prover {
+    /// Creates a new prover with the provided context.
+    pub fn new(context: ProverContext) -> Self {
+        Self { context }
+    }
+
+    /// Executes proof generation over the supplied AIR instance.
+    pub fn prove(&self, _air: &dyn Air) -> StarkResult<ProofBytes> {
+        let trace_length = self.context.stark.trace_length;
+        if trace_length == 0 {
+            return Err(StarkError::InvalidInput("trace length must be non-zero"));
+        }
+        let fri_proof = FriProof::new();
+        let batch = FriBatch::new(vec![fri_proof]);
+        if !batch.verify()? {
+            return Err(StarkError::SubsystemFailure("fri self-check failed"));
+        }
+        let hasher = Blake3Hasher::new(self.context.stark.hash.blake3.clone());
+        let merkle = MerkleTree::new(vec![hasher.finalize()?])?;
+        let _root = merkle.root(Blake3Hasher::new(self.context.stark.hash.blake3.clone()))?;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&trace_length.to_le_bytes());
+        Ok(ProofBytes::new(bytes))
+    }
+
+    /// High-level proof generation entry point used by the library API.
+    pub fn create_proof(&self) -> StarkResult<ProofBytes> {
+        // Placeholder invocation without a specific AIR instance.
+        Err(StarkError::NotImplemented(
+            "prover::create_proof requires AIR instance",
+        ))
+    }
+}

--- a/src/proof/verifier.rs
+++ b/src/proof/verifier.rs
@@ -1,0 +1,37 @@
+//! Verifier implementation for the `rpp-stark` engine.
+//! Performs deterministic checks over provided proofs.
+
+use crate::config::VerifierContext;
+use crate::fri::{FriBatch, FriProof};
+use crate::hash::Blake3Hasher;
+use crate::utils::serialization::ProofBytes;
+use crate::{StarkError, StarkResult};
+
+/// Verifier struct encapsulating deterministic verification logic.
+#[derive(Debug, Clone)]
+pub struct Verifier {
+    /// Context containing configuration parameters.
+    pub context: VerifierContext,
+}
+
+impl Verifier {
+    /// Constructs a new verifier.
+    pub fn new(context: VerifierContext) -> Self {
+        Self { context }
+    }
+
+    /// Verifies the provided proof bytes against the context.
+    pub fn verify(&self, proof: &ProofBytes) -> StarkResult<bool> {
+        if proof.as_slice().is_empty() {
+            return Err(StarkError::InvalidInput("proof bytes cannot be empty"));
+        }
+        let fri_proof = FriProof::new();
+        let batch = FriBatch::new(vec![fri_proof]);
+        if !batch.verify()? {
+            return Ok(false);
+        }
+        let mut hasher = Blake3Hasher::new(self.context.stark.hash.blake3.clone());
+        let digest = hasher.hash(proof.as_slice())?;
+        Ok(digest[0] & 1 == 0)
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,8 @@
+//! Utility helpers for the `rpp-stark` engine.
+//! Includes deterministic randomness and serialization helpers.
+
+pub mod randomness;
+pub mod serialization;
+
+pub use randomness::DeterministicRng;
+pub use serialization::ProofBytes;

--- a/src/utils/randomness.rs
+++ b/src/utils/randomness.rs
@@ -1,0 +1,43 @@
+//! Deterministic randomness generation based on Blake3 transcripts.
+//! Provides a reproducible RNG for sampling queries and challenges.
+
+use crate::hash::config::Blake3Parameters;
+use crate::hash::Blake3Hasher;
+use crate::{StarkError, StarkResult};
+
+/// Deterministic random number generator derived from Blake3.
+#[derive(Debug, Clone)]
+pub struct DeterministicRng {
+    /// Underlying hasher used to produce pseudorandom output.
+    hasher: Blake3Hasher,
+    /// Counter ensuring unique outputs per request.
+    counter: u64,
+}
+
+impl DeterministicRng {
+    /// Creates a new RNG with the provided parameters.
+    pub fn new(params: Blake3Parameters) -> Self {
+        Self {
+            hasher: Blake3Hasher::new(params),
+            counter: 0,
+        }
+    }
+
+    /// Produces the next pseudorandom field element seed as 32 bytes.
+    pub fn next_bytes(&mut self) -> StarkResult<[u8; 32]> {
+        self.counter = self.counter.wrapping_add(1);
+        let mut data = Vec::new();
+        data.extend_from_slice(&self.counter.to_le_bytes());
+        self.hasher.absorb(&data);
+        self.hasher.finalize()
+    }
+
+    /// Reseeds the transcript with deterministic additional data.
+    pub fn reseed(&mut self, seed: &[u8]) -> StarkResult<()> {
+        if seed.is_empty() {
+            return Err(StarkError::InvalidInput("reseed seed cannot be empty"));
+        }
+        self.hasher.absorb(seed);
+        Ok(())
+    }
+}

--- a/src/utils/serialization.rs
+++ b/src/utils/serialization.rs
@@ -1,0 +1,21 @@
+//! Serialization utilities for proofs and transcripts.
+//! Provides deterministic byte representations for cross-component communication.
+
+/// Wrapper around proof bytes ensuring explicit conversions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofBytes {
+    /// Raw proof representation.
+    bytes: Vec<u8>,
+}
+
+impl ProofBytes {
+    /// Creates a new proof byte container.
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    /// Returns the underlying byte slice.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.bytes
+    }
+}


### PR DESCRIPTION
## Summary
- add the rpp-stark crate manifest and high-level library entry points with deterministic error handling
- sketch core modules for field arithmetic, FFT/LDE, hashing, AIR, FRI, and proof contexts with documentation scaffolding
- provide utility structures for configuration, deterministic randomness, and proof serialization to support the prover/verifier pipeline

## Testing
- `cargo fmt`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68e17f05bf688326bdd0bbbbaaf8a888